### PR TITLE
Add a sumMoney method to collections

### DIFF
--- a/src/MoneyServiceProvider.php
+++ b/src/MoneyServiceProvider.php
@@ -13,5 +13,15 @@ class MoneyServiceProvider extends ServiceProvider
     {
         BladeExtension::register($this->app->make('blade.compiler'));
         Money::setLocale($this->app->make('translator')->getLocale());
+        
+        Collection::macro('sumMoney', function ($callback) {
+            $callback = $this->valueRetriever($callback);
+            return $this->reduce(function (Money $result, $item) use ($callback) {
+            if (!$amount = $callback($item)) {
+                $amount = money('0');
+            }
+            return $result->add($amount);
+            }, money('0'));
+        });
     }
 }


### PR DESCRIPTION
This allows $collection->sumMoney('attribute') to be used to get a total of money attributes.