### PR TITLE
Add the ability to macro the Money class

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -5,6 +5,7 @@ namespace Cknow\Money;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Traits\Macroable;
 use JsonSerializable;
 use Money\Currency;
 
@@ -15,6 +16,9 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
     use MoneyFactory;
     use MoneyFormatterTrait;
     use MoneyParserTrait;
+    use Macroable {
+        __call as macroCall;
+    }
 
     /**
      * @var \Money\Money
@@ -47,6 +51,10 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
      */
     public function __call($method, array $arguments)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $arguments);
+        }
+
         if (!method_exists($this->money, $method)) {
             return $this;
         }

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -180,4 +180,18 @@ class MoneyTest extends \PHPUnit\Framework\TestCase
             ['amount' => '100', 'currency' => 'USD', 'formatted' => '$1.00', 'foo' => 'bar']
         );
     }
+
+    public function testMacroable()
+    {
+        Money::macro('someMacro', function () {
+            return 'some-return-value';
+        });
+
+        $money = new Money(100, new Currency('USD'));
+
+        static::assertEquals(
+            'some-return-value',
+            $money->someMacro()
+        );
+    }
 }


### PR DESCRIPTION
Use the `Macroable` trait.

I'm not sure if this is helpful to some but I'd mostly use this to keep custom formatters within the Money instance.

As an example:

```php
class MyFormatter implements \Money\MoneyFormatter
{
    public function format(\Money\Money $money)
    {
        return 'My Formatter';
    }
}

Money::macro('toMyFormatter', function () {
    return $this->formatByFormatter(new MyFormatter());
})

Money::USD(500)->toMyFormatter(); // My Formatter
```