### PR TITLE
refactor: Make it easier for classes to extend

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -23,12 +23,12 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
     /**
      * @var \Money\Money
      */
-    private $money;
+    protected $money;
 
     /**
      * @var array
      */
-    private $attributes = [];
+    protected $attributes = [];
 
     /**
      * Money.

--- a/src/Money.php
+++ b/src/Money.php
@@ -107,7 +107,7 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
     /**
      * Convert.
      *
-     * @param \Money\Money $intance
+     * @param \Money\Money $instance
      *
      * @return \Cknow\Money\Money
      */

--- a/src/Money.php
+++ b/src/Money.php
@@ -59,7 +59,7 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
             return $this;
         }
 
-        $result = call_user_func_array([$this->money, $method], self::getArguments($arguments));
+        $result = call_user_func_array([$this->money, $method], static::getArguments($arguments));
 
         $methods = [
             'add', 'subtract',
@@ -72,7 +72,7 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
             return $result;
         }
 
-        return self::convertResult($result);
+        return static::convertResult($result);
     }
 
     /**
@@ -96,9 +96,9 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
     public static function __callStatic($method, array $arguments)
     {
         if (in_array($method, ['min', 'max', 'avg', 'sum'])) {
-            $result = call_user_func_array([\Money\Money::class, $method], self::getArguments($arguments));
+            $result = call_user_func_array([\Money\Money::class, $method], static::getArguments($arguments));
 
-            return self::convert($result);
+            return static::convert($result);
         }
 
         return MoneyFactory::__callStatic($method, $arguments);
@@ -111,9 +111,9 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
      *
      * @return \Cknow\Money\Money
      */
-    public static function convert(\Money\Money $intance)
+    public static function convert(\Money\Money $instance)
     {
-        return new self($intance->getAmount(), $intance->getCurrency());
+        return new static($instance->getAmount(), $instance->getCurrency());
     }
 
     /**
@@ -194,7 +194,7 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
         $args = [];
 
         foreach ($arguments as $argument) {
-            $args[] = $argument instanceof self ? $argument->getMoney() : $argument;
+            $args[] = $argument instanceof static ? $argument->getMoney() : $argument;
         }
 
         return $args;
@@ -210,13 +210,13 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
     private static function convertResult($result)
     {
         if (!is_array($result)) {
-            return self::convert($result);
+            return static::convert($result);
         }
 
         $results = [];
 
         foreach ($result as $item) {
-            $results[] = self::convert($item);
+            $results[] = static::convert($item);
         }
 
         return $results;

--- a/src/MoneyParserTrait.php
+++ b/src/MoneyParserTrait.php
@@ -25,7 +25,7 @@ trait MoneyParserTrait
      */
     public static function parse($money, $forceCurrency = null, $locale = null, Currencies $currencies = null)
     {
-        return self::parseByIntl($money, $forceCurrency, $locale, $currencies);
+        return static::parseByIntl($money, $forceCurrency, $locale, $currencies);
     }
 
     /**
@@ -41,7 +41,7 @@ trait MoneyParserTrait
     {
         $parser = new AggregateMoneyParser($parsers);
 
-        return self::parseByParser($parser, $money, $forceCurrency);
+        return static::parseByParser($parser, $money, $forceCurrency);
     }
 
     /**
@@ -57,7 +57,7 @@ trait MoneyParserTrait
     {
         $parser = new BitcoinMoneyParser($fractionDigits);
 
-        return self::parseByParser($parser, $money, $forceCurrency);
+        return static::parseByParser($parser, $money, $forceCurrency);
     }
 
     /**
@@ -73,7 +73,7 @@ trait MoneyParserTrait
     {
         $parser = new DecimalMoneyParser($currencies ?: static::getCurrencies());
 
-        return self::parseByParser($parser, $money, $forceCurrency);
+        return static::parseByParser($parser, $money, $forceCurrency);
     }
 
     /**
@@ -97,7 +97,7 @@ trait MoneyParserTrait
         $numberFormatter = new NumberFormatter($locale ?: static::getLocale(), $style);
         $parser = new IntlMoneyParser($numberFormatter, $currencies ?: static::getCurrencies());
 
-        return self::parseByParser($parser, $money, $forceCurrency);
+        return static::parseByParser($parser, $money, $forceCurrency);
     }
 
     /**
@@ -121,7 +121,7 @@ trait MoneyParserTrait
         $numberFormatter = new NumberFormatter($locale ?: static::getLocale(), $style);
         $parser = new IntlLocalizedDecimalParser($numberFormatter, $currencies ?: static::getCurrencies());
 
-        return self::parseByParser($parser, $money, $forceCurrency);
+        return static::parseByParser($parser, $money, $forceCurrency);
     }
 
     /**


### PR DESCRIPTION
This makes it possible to extend the Money class without having to overwrite lots of different methods in order to return an instance of the subclass

e.g. This is currently not possible without this change
```php
class Money extends \Cknow\Money\Money
{
    public static function sumCollection(Collection $collection): self
    {
        $first = $collection->shift();
        $all = $collection->all();

        return static::sum($first, ...$all);
    }
}
```