### PR TITLE
Update dependencies to Laravel 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 vendor/
 composer.lock
 .php_cs.cache
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
-    - php: 7.1
-      env: setup=lowest
     - php: 7.2
     - php: 7.2
       env: setup=lowest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,6 @@ clone_folder: c:\projects\laravel-money
 
 environment:
   matrix:
-    - php_ver: 7.1.32
     - php_ver: 7.2.22
     - php_ver: 7.3.9
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "source": "https://github.com/cknow/laravel-money"
   },
   "require": {
-    "php": "^7.1",
+    "php": "^7.2.5",
     "ext-json": "*",
     "ext-intl": "*",
     "illuminate/support": "^5.5|^6.0|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "phpmd/phpmd": "^2.7",
     "phpro/grumphp": "^0.15.2",
     "phpstan/phpstan": "^0.11",
-    "phpunit/phpunit": "^7.0",
+    "phpunit/phpunit": "^8.5",
     "povils/phpmnd": "^2.1",
     "sebastian/phpcpd": "^4.1",
     "sensiolabs/security-checker": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -21,17 +21,17 @@
     "source": "https://github.com/cknow/laravel-money"
   },
   "require": {
-    "php": "^7.2.5",
+    "php": "^7.2",
     "ext-json": "*",
     "ext-intl": "*",
-    "illuminate/support": "^5.5|^6.0|^7.0",
-    "illuminate/view": "^5.5|^6.0|^7.0",
+    "illuminate/support": "^6.0|^7.0",
+    "illuminate/view": "^6.0|^7.0",
     "moneyphp/money": "^3.2"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.15",
     "graham-campbell/testbench": "^5.3",
-    "illuminate/filesystem": "^5.5|^6.0|^7.0",
+    "illuminate/filesystem": "^6.0|^7.0",
     "jakub-onderka/php-parallel-lint": "^1.0",
     "mockery/mockery": "^1.2",
     "nikic/php-parser": "^4.2",

--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,14 @@
     "php": "^7.1",
     "ext-json": "*",
     "ext-intl": "*",
-    "illuminate/support": "^5.5|^6.0",
-    "illuminate/view": "^5.5|^6.0",
+    "illuminate/support": "^5.5|^6.0|^7.0",
+    "illuminate/view": "^5.5|^6.0|^7.0",
     "moneyphp/money": "^3.2"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.15",
     "graham-campbell/testbench": "^5.3",
-    "illuminate/filesystem": "^5.5|^6.0",
+    "illuminate/filesystem": "^5.5|^6.0|^7.0",
     "jakub-onderka/php-parallel-lint": "^1.0",
     "mockery/mockery": "^1.2",
     "nikic/php-parser": "^4.2",

--- a/tests/BladeExtensionTest.php
+++ b/tests/BladeExtensionTest.php
@@ -15,7 +15,7 @@ class BladeExtensionTest extends \PHPUnit\Framework\TestCase
      */
     protected $compiler;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -24,7 +24,7 @@ class BladeExtensionTest extends \PHPUnit\Framework\TestCase
         BladeExtension::register($this->compiler);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -7,7 +7,7 @@ use Money\Currency;
 
 class HelpersTest extends \PHPUnit\Framework\TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         Money::setCurrencies(new ISOCurrencies());
         Money::setLocale('en_US');

--- a/tests/MoneyFactoryTest.php
+++ b/tests/MoneyFactoryTest.php
@@ -10,7 +10,7 @@ use Money\Currency;
  */
 class MoneyFactoryTest extends \PHPUnit\Framework\TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         Money::setCurrencies(new ISOCurrencies());
         Money::setLocale('en_US');

--- a/tests/MoneyFormatterTraitTest.php
+++ b/tests/MoneyFormatterTraitTest.php
@@ -15,7 +15,7 @@ use NumberFormatter as N;
  */
 class MoneyFormatterTraitTest extends \PHPUnit\Framework\TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         Money::setCurrencies(new ISOCurrencies());
         Money::setLocale('en_US');

--- a/tests/MoneyParserTraitTest.php
+++ b/tests/MoneyParserTraitTest.php
@@ -13,7 +13,7 @@ use NumberFormatter;
  */
 class MoneyParserTraitTest extends \PHPUnit\Framework\TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         Money::setCurrencies(new ISOCurrencies());
         Money::setLocale('en_US');

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -10,7 +10,7 @@ use Money\Currency;
  */
 class MoneyTest extends \PHPUnit\Framework\TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         Money::setCurrencies(new ISOCurrencies());
         Money::setLocale('en_US');


### PR DESCRIPTION
Bumps the dependencies to include Laravel ^7.0 variants.

I've forked and been running this locally, and it appears there's no breaking changes affecting the package in Laravel 7.