### PR TITLE
Add a way to specify the parser used when casting

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -15,5 +15,6 @@ return [
             // 'MY1' => 2,
             // 'MY2' => 3
         ]
-    ]
+    ],
+    'perferred_caster_parser' => 'parseByDecimal'
 ];

--- a/src/MoneyCast.php
+++ b/src/MoneyCast.php
@@ -41,11 +41,29 @@ class MoneyCast implements CastsAttributes
             return $value;
         }
 
-        return Money::parseByDecimal(
-            $value,
-            $this->getCurrency($attributes),
-            Money::getCurrencies()
-        );
+        $preferred_casts = config('money.perferred_caster_parser', 'parseByDecimal');
+
+        switch ($preferred_casts) {
+            case 'parse':
+                return Money::parse(
+                    $value,
+                    $this->getCurrency($attributes)
+                );
+            break;
+            case 'parseByDecimal':
+                return Money::parseByDecimal(
+                    $value,
+                    $this->getCurrency($attributes),
+                    Money::getCurrencies()
+                );
+            break;
+            default:
+                return Money::parseByDecimal(
+                    $value,
+                    $this->getCurrency($attributes),
+                    Money::getCurrencies()
+                );
+        }
     }
 
     /**


### PR DESCRIPTION
Add's a simple config option to allow different parsers to be used on the caster.