### PR TITLE
Laravel 8 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4]
-        laravel: [7.*]
+        php: [7.3, 7.4]
+        laravel: [7.*, 8.*]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/composer.json
+++ b/composer.json
@@ -19,16 +19,16 @@
         "source": "https://github.com/cknow/laravel-money"
     },
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.3.0",
         "ext-json": "*",
         "ext-intl": "*",
-        "illuminate/support": "^7.0",
-        "illuminate/view": "^7.0",
+        "illuminate/support": "^7.0|^8.0",
+        "illuminate/view": "^7.0|^8.0",
         "moneyphp/money": "^3.3"
     },
     "require-dev": {
-        "graham-campbell/testbench": "^5.4",
-        "illuminate/filesystem": "^7.0",
+        "graham-campbell/testbench": "^5.5",
+        "illuminate/filesystem": "^7.0|^8.0",
         "mockery/mockery": "^1.3",
         "phpunit/phpunit": "^8.5|^9.0"
     },


### PR DESCRIPTION
This PR adds support for Laravel 8.

The minimum PHP version is now 7.3.0.