### PR TITLE
Added new Cast type

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,18 @@ At this stage the cast can be defined in the following ways:
 
 ```php
 protected $casts = [
-    // cast money using the currency defined in the package config
+    // cast money using the currency defined in the package config, storing it as decimals
     'money' => MoneyCast::class,
-    // cast money using the defined currency
+    // cast money using the defined currency, storing it as decimals
     'money' => MoneyCast::class . ':AUD',
-    // cast money using the currency defined in the model attribute 'currency'
+    // cast money using the currency defined in the model attribute 'currency', storing it as decimals
     'money' => MoneyCast::class . ':currency',
+    // cast money using the currency defined in the package config, storing it as integer (1000 => 10.00)
+    'money' => MoneyIntCast::class,
+    // cast money using the defined currency, storing it as integer (1000 => 10.00)
+    'money' => MoneyIntCast::class . ':AUD',
+    // cast money using the currency defined in the model attribute 'currency', storing it as integer (1000 => 10.00)
+    'money' => MoneyIntCast::class . ':currency',
 ];
 ```
 
@@ -167,6 +173,8 @@ $model->money = '€13';
 $model->currency; // 'EUR'
 $model->money->getAmount(); // '1300'
 ```
+
+When using `MoneyCast`, the value will be stored through eloquent in decimal format, while using `MoneyIntCast` will store the value using an integer representing the lowest currency unit available ($10.00 will be stored as 1000).
 
 ## Helpers
 

--- a/src/MoneyIntCast.php
+++ b/src/MoneyIntCast.php
@@ -1,0 +1,129 @@
+<?php
+
+
+namespace Cknow\Money;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use InvalidArgumentException;
+use Money\Currency;
+use Money\Exception\ParserException;
+
+class MoneyIntCast implements CastsAttributes
+{
+    /**
+     * The currency code or the model attribute holding the currency code.
+     *
+     * @var string|null
+     */
+    protected $currency;
+
+    /**
+     * Instantiate the class.
+     *
+     * @param string|null $currency
+     */
+    public function __construct(string $currency = null)
+    {
+        $this->currency = $currency;
+    }
+
+    /**
+     * Transform the attribute from the underlying model values.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param string                              $key
+     * @param mixed                               $value
+     * @param array                               $attributes
+     *
+     * @return \Cknow\Money\Money|null
+     */
+    public function get($model, string $key, $value, array $attributes)
+    {
+        if ($value === null) {
+            return $value;
+        }
+
+        if ($value instanceof Money) {
+            return $value;
+        }
+
+        if ($value instanceof  \Money\Money) {
+            return Money::fromMoney($value);
+        }
+
+        return new Money(
+            $value,
+            $this->getCurrency($attributes)
+        );
+    }
+
+    /**
+     * Transform the attribute to its underlying model values.
+     *
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param string                              $key
+     * @param mixed                               $value
+     * @param array                               $attributes
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return array
+     */
+    public function set($model, string $key, $value, array $attributes)
+    {
+        if ($value === null) {
+            return [$key => $value];
+        }
+
+        $money = $value;
+        if (!$value instanceof Money) {
+            try {
+                $currency = $this->getCurrency($attributes);
+                try {
+                    $money = Money::parseByDecimal($value, $currency);
+                } catch (ParserException $e) {
+                    $money = Money::parse($value, $currency);
+                }
+            } catch (InvalidArgumentException $e) {
+                throw new InvalidArgumentException(
+                    sprintf('Invalid data provided for %s::$%s', get_class($model), $key)
+                );
+            }
+        }
+
+        $amount = $money->getAmount();
+
+        if (array_key_exists($this->currency, $attributes)) {
+            return [$key => $amount, $this->currency => $money->getCurrency()->getCode()];
+        }
+
+        return [$key => $amount];
+    }
+
+    /**
+     * Retrieve the money.
+     *
+     * @param array $attributes
+     *
+     * @return \Money\Currency
+     */
+    protected function getCurrency(array $attributes)
+    {
+        $defaultCode = Money::getDefaultCurrency();
+
+        if ($this->currency === null) {
+            return new Currency($defaultCode);
+        }
+
+        $currency = new Currency($this->currency);
+        $currencies = Money::getCurrencies();
+
+        if ($currencies->contains($currency)) {
+            return $currency;
+        }
+
+        $code = $attributes[$this->currency] ?? $defaultCode;
+
+        return new Currency($code);
+    }
+}

--- a/tests/Database/Models/UserInt.php
+++ b/tests/Database/Models/UserInt.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Cknow\Money\Tests\Database\Models;
+
+use Cknow\Money\MoneyIntCast;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * The testing user model.
+ */
+class UserInt extends Model
+{
+    protected $table = 'users';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'money',
+        'wage',
+        'debits',
+        'currency',
+    ];
+
+    /**
+     * The attributes to cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'money' => MoneyIntCast::class,
+        'wage' => MoneyIntCast::class.':EUR',
+        'debits' => MoneyIntCast::class.':currency',
+    ];
+}

--- a/tests/MoneyIntCastTest.php
+++ b/tests/MoneyIntCastTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Cknow\Money\Tests;
+
+use Cknow\Money\Money;
+use Cknow\Money\MoneyServiceProvider;
+use Cknow\Money\Tests\Database\Models\User;
+use Cknow\Money\Tests\Database\Models\UserInt;
+use GrahamCampbell\TestBench\AbstractPackageTestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use InvalidArgumentException;
+use Money\Exception\ParserException;
+use Money\Money as BaseMoney;
+use stdClass;
+
+/**
+ * The money cast test.
+ */
+class MoneyIntCastTest extends AbstractPackageTestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadMigrationsFrom(__DIR__.'/Database/Migrations');
+
+        Money::setCurrencies(config('money.currencies'));
+    }
+
+    public function testCastsMoneyWhenRetrievingCastedValues()
+    {
+        $user = UserInt::create([
+            'money' => 1234.56,
+            'wage' => 50000,
+            'debits' => null,
+            'currency' => 'AUD',
+        ]);
+
+        static::assertInstanceOf(Money::class, $user->money);
+        static::assertInstanceOf(Money::class, $user->wage);
+        static::assertNull($user->debits);
+
+        static::assertSame('123456', $user->money->getAmount());
+        static::assertSame('USD', $user->money->getCurrency()->getCode());
+
+        static::assertSame('5000000', $user->wage->getAmount());
+        static::assertSame('EUR', $user->wage->getCurrency()->getCode());
+
+        $user->debits = 10099;
+
+        static::assertSame('1009900', $user->debits->getAmount());
+        static::assertSame('AUD', $user->debits->getCurrency()->getCode());
+
+        $user->save();
+
+        static::assertSame(1, $user->id);
+
+        $this->assertDatabaseHas('users', [
+            'id' => 1,
+            'money' => 123456,
+            'wage' => 5000000,
+            'debits' => 1009900,
+            'currency' => 'AUD',
+        ]);
+    }
+
+    public function testCastsMoneyWhenSettingCastedValues()
+    {
+        $user = new UserInt([
+            'money' => 0,
+            'wage' => '6500000',
+            'debits' => null,
+            'currency' => 'CAD',
+        ]);
+
+        static::assertSame('0', $user->money->getAmount());
+        static::assertSame('USD', $user->money->getCurrency()->getCode());
+
+        static::assertSame('650000000', $user->wage->getAmount());
+        static::assertSame('EUR', $user->wage->getCurrency()->getCode());
+
+        static::assertNull($user->debits);
+
+        $user->money = new BaseMoney(10000, $user->money->getCurrency());
+
+        static::assertSame('10000', $user->money->getAmount());
+
+        $user->money = 100;
+        $user->wage = 70500.19;
+        $user->debits = '¥213860';
+
+        static::assertSame('10000', $user->money->getAmount());
+        static::assertSame('USD', $user->money->getCurrency()->getCode());
+
+        static::assertSame('7050019', $user->wage->getAmount());
+        static::assertSame('EUR', $user->wage->getCurrency()->getCode());
+
+        static::assertSame('213860', $user->debits->getAmount());
+        static::assertSame('JPY', $user->debits->getCurrency()->getCode());
+        static::assertSame('JPY', $user->currency);
+
+        $user->money = '100,000.22';
+        $user->debits = 'Ƀ0.00012345';
+
+        static::assertSame('10000022', $user->money->getAmount());
+        static::assertSame('USD', $user->money->getCurrency()->getCode());
+
+        static::assertSame('12345', $user->debits->getAmount());
+        static::assertSame('XBT', $user->debits->getCurrency()->getCode());
+        static::assertSame('XBT', $user->currency);
+
+        $user->save();
+
+        static::assertSame(1, $user->id);
+
+        $this->assertDatabaseHas('users', [
+            'id' => 1,
+            'money' => 10000022,
+            'wage' => 7050019,
+            'debits' => 12345,
+            'currency' => 'XBT',
+        ]);
+    }
+
+    public function testFailsToSetInvalidMoney()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid data provided for Cknow\Money\Tests\Database\Models\User::$money');
+
+        new User(['money' => new stdClass()]);
+    }
+
+    public function testFailsToParseInvalidMoney()
+    {
+        $this->expectException(ParserException::class);
+        $this->expectExceptionMessage('Unable to parse: abc');
+
+        new UserInt(['money' => 'abc']);
+    }
+
+    /**
+     * Get the service provider class.
+     *
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     *
+     * @return string
+     */
+    protected function getServiceProviderClass($app)
+    {
+        return MoneyServiceProvider::class;
+    }
+}


### PR DESCRIPTION
This PR attemps to add support for storing the values as integer / string in the database, which is the core concept at the base of the money pattern.

As suggested on https://github.com/cknow/laravel-money/issues/62 the strategy adopted is to add a new caster class.

I also updated docs and tests to reflect the changes.