### PR TITLE
Feat MoneyIntegerCast, MoneyStringCast, MoneyDecimalCast

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,15 +134,17 @@ Money::USD(500)->formatByFormatter(new MyFormatter()); // My Formatter
 At this stage the cast can be defined in the following ways:
 
 ```php
-use Cknow\Money\MoneyCast;
+use Cknow\Money\MoneyDecimalCast;
+use Cknow\Money\MoneyIntegerCast;
+use Cknow\Money\MoneyStringCast;
 
 protected $casts = [
-    // cast money using the currency defined in the package config
-    'money' => MoneyCast::class,
-    // cast money using the defined currency
-    'money' => MoneyCast::class . ':AUD',
-    // cast money using the currency defined in the model attribute 'currency'
-    'money' => MoneyCast::class . ':currency',
+    // cast money as decimal using the currency defined in the package config
+    'money' => MoneyDecimalCast::class,
+    // cast money as integer using the defined currency
+    'money' => MoneyIntegerCast::class . ':AUD',
+    // cast money as string using the currency defined in the model attribute 'currency'
+    'money' => MoneyStringCast::class . ':currency',
 ];
 ```
 

--- a/src/MoneyCast.php
+++ b/src/MoneyCast.php
@@ -40,11 +40,7 @@ class MoneyCast implements CastsAttributes
             return $value;
         }
 
-        return Money::parseByDecimal(
-            $value,
-            $this->getCurrency($attributes),
-            Money::getCurrencies()
-        );
+        return Money::parse($value, $this->getCurrency($attributes));
     }
 
     /**
@@ -73,7 +69,7 @@ class MoneyCast implements CastsAttributes
             );
         }
 
-        $amount = $money->formatByDecimal(Money::getCurrencies());
+        $amount = $this->getFormatter($money);
 
         if (array_key_exists($this->currency, $attributes)) {
             return [$key => $amount, $this->currency => $money->getCurrency()->getCode()];
@@ -83,7 +79,18 @@ class MoneyCast implements CastsAttributes
     }
 
     /**
-     * Retrieve the money.
+     * Get formatter.
+     *
+     * @param  \Cknow\Money\Money  $money
+     * @return mixed
+     */
+    protected function getFormatter(Money $money)
+    {
+        return $money->formatByDecimal();
+    }
+
+    /**
+     * Get currency.
      *
      * @param  array  $attributes
      * @return \Money\Currency
@@ -93,6 +100,7 @@ class MoneyCast implements CastsAttributes
         $defaultCode = Money::getDefaultCurrency();
 
         if ($this->currency === null) {
+
             return new Currency($defaultCode);
         }
 

--- a/src/MoneyCast.php
+++ b/src/MoneyCast.php
@@ -100,7 +100,6 @@ class MoneyCast implements CastsAttributes
         $defaultCode = Money::getDefaultCurrency();
 
         if ($this->currency === null) {
-
             return new Currency($defaultCode);
         }
 

--- a/src/MoneyDecimalCast.php
+++ b/src/MoneyDecimalCast.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Cknow\Money;
+
+class MoneyDecimalCast extends MoneyCast
+{
+    protected function getFormatter(Money $money)
+    {
+        return $money->formatByDecimal();
+    }
+}

--- a/src/MoneyIntegerCast.php
+++ b/src/MoneyIntegerCast.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Cknow\Money;
+
+class MoneyIntegerCast extends MoneyCast
+{
+    protected function getFormatter(Money $money)
+    {
+        return $money->getAmount();
+    }
+}

--- a/src/MoneyStringCast.php
+++ b/src/MoneyStringCast.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Cknow\Money;
+
+class MoneyStringCast extends MoneyCast
+{
+    protected function getFormatter(Money $money)
+    {
+        return $money->format();
+    }
+}

--- a/tests/Database/Migrations/2020_04_30_000000_create_users_table.php
+++ b/tests/Database/Migrations/2020_04_30_000000_create_users_table.php
@@ -17,10 +17,11 @@ class CreateUsersTable extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
-            $table->decimal('money', 15, 2);
-            $table->decimal('wage', 15, 2);
+            $table->string('money');
+            $table->integer('wage')->nullable();
             $table->decimal('debits', 15, 2)->nullable();
-            $table->string('currency');
+            $table->decimal('credits', 15, 2)->nullable();
+            $table->string('currency')->nullable();
             $table->timestamps();
         });
     }

--- a/tests/Database/Models/User.php
+++ b/tests/Database/Models/User.php
@@ -32,7 +32,7 @@ class User extends Model
      * @var array
      */
     protected $casts = [
-        'money' => MoneyStringCast::class.':USD',
+        'money' => MoneyStringCast::class,
         'wage' => MoneyIntegerCast::class.':EUR',
         'debits' => MoneyDecimalCast::class.':currency',
         'credits' => MoneyCast::class.':USD',

--- a/tests/Database/Models/User.php
+++ b/tests/Database/Models/User.php
@@ -3,6 +3,9 @@
 namespace Cknow\Money\Tests\Database\Models;
 
 use Cknow\Money\MoneyCast;
+use Cknow\Money\MoneyDecimalCast;
+use Cknow\Money\MoneyIntegerCast;
+use Cknow\Money\MoneyStringCast;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -19,6 +22,7 @@ class User extends Model
         'money',
         'wage',
         'debits',
+        'credits',
         'currency',
     ];
 
@@ -28,8 +32,9 @@ class User extends Model
      * @var array
      */
     protected $casts = [
-        'money' => MoneyCast::class,
-        'wage' => MoneyCast::class.':EUR',
-        'debits' => MoneyCast::class.':currency',
+        'money' => MoneyStringCast::class.':USD',
+        'wage' => MoneyIntegerCast::class.':EUR',
+        'debits' => MoneyDecimalCast::class.':currency',
+        'credits' => MoneyCast::class.':USD',
     ];
 }

--- a/tests/MoneyCastTest.php
+++ b/tests/MoneyCastTest.php
@@ -143,24 +143,6 @@ class MoneyCastTest extends AbstractPackageTestCase
         new User(['money' => new stdClass()]);
     }
 
-    public function testCastsMoneyWithDefaultCurrency()
-    {
-        $user = User::create(['money' => '1.00']);
-
-        static::assertInstanceOf(Money::class, $user->money);
-        static::assertSame('100', $user->money->getAmount());
-        static::assertSame('USD', $user->money->getCurrency()->getCode());
-
-        $user->save();
-
-        static::assertSame(1, $user->id);
-
-        $this->assertDatabaseHas('users', [
-            'id' => 1,
-            'money' => '$1.00',
-        ]);
-    }
-
     public function testFailsToParseInvalidMoney()
     {
         $this->expectException(ParserException::class);

--- a/tests/MoneyCastTest.php
+++ b/tests/MoneyCastTest.php
@@ -69,7 +69,7 @@ class MoneyCastTest extends AbstractPackageTestCase
 
         $this->assertDatabaseHas('users', [
             'id' => 1,
-            'money' => "$1,234.56",
+            'money' => '$1,234.56',
             'wage' => 50000,
             'debits' => 100.99,
             'credits' => 99,
@@ -128,7 +128,7 @@ class MoneyCastTest extends AbstractPackageTestCase
 
         $this->assertDatabaseHas('users', [
             'id' => 1,
-            'money' => "$100,000.22",
+            'money' => '$100,000.22',
             'wage' => 7050019,
             'debits' => 0.00012345,
             'currency' => 'XBT',
@@ -157,7 +157,7 @@ class MoneyCastTest extends AbstractPackageTestCase
 
         $this->assertDatabaseHas('users', [
             'id' => 1,
-            'money' => "$1.00",
+            'money' => '$1.00',
         ]);
     }
 

--- a/tests/MoneyParserTraitTest.php
+++ b/tests/MoneyParserTraitTest.php
@@ -4,18 +4,28 @@ namespace Cknow\Money\Tests;
 
 use Cknow\Money\Money;
 use Money\Currency;
+use Money\Exception\ParserException;
 use Money\Parser\BitcoinMoneyParser;
 use Money\Parser\DecimalMoneyParser;
 use Money\Parser\IntlMoneyParser;
 use NumberFormatter;
 use PHPUnit\Framework\TestCase;
+use stdClass;
+use InvalidArgumentException;
 
 class MoneyParserTraitTest extends TestCase
 {
     public function testParse()
     {
+        static::assertEquals(Money::parse('100.00', 'USD'), Money::USD(10000));
         static::assertEquals(Money::parse('$1.00'), Money::USD(100));
         static::assertEquals(Money::parse('$1.00', 'USD'), Money::USD(100));
+        static::assertEquals(Money::parse(1, 'USD'), Money::USD(1));
+        static::assertEquals(Money::parse(1.10, 'USD'), Money::USD(110));
+        static::assertEquals(Money::parse('100', 'USD'), Money::USD(100));
+        static::assertEquals(Money::parse('1', 'USD'), Money::USD(1));
+        static::assertEquals(Money::parse(Money::USD(100)), Money::USD(100));
+        static::assertEquals(Money::parse(new \Money\Money(100, new Currency('USD'))), Money::USD(100));
     }
 
     public function testParseByAggregate()
@@ -29,7 +39,6 @@ class MoneyParserTraitTest extends TestCase
             ),
         ];
 
-        // static::assertEquals(Money::parseByAggregate("\xC9\x831000.00", 'EUR', $parsers), Money::XBT(100000));
         static::assertEquals(Money::parseByAggregate('1.00', 'EUR', $parsers), Money::EUR(100));
         static::assertEquals(Money::parseByAggregate('$1.00', 'EUR', $parsers), Money::EUR(100));
     }
@@ -72,5 +81,21 @@ class MoneyParserTraitTest extends TestCase
 
         static::assertEquals(Money::parseByParser($parser, '1.00', 'USD'), Money::USD(100));
         static::assertEquals(Money::parseByParser($parser, '1.00', new Currency('EUR')), Money::EUR(100));
+    }
+
+    public function testParseInvalidMoneyValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid value {}');
+
+        Money::parse(new stdClass());
+    }
+
+    public function testParseInvalidMoney()
+    {
+        $this->expectException(ParserException::class);
+        $this->expectExceptionMessage('Unable to parse abc');
+
+        Money::parse('abc');
     }
 }

--- a/tests/MoneyParserTraitTest.php
+++ b/tests/MoneyParserTraitTest.php
@@ -3,6 +3,7 @@
 namespace Cknow\Money\Tests;
 
 use Cknow\Money\Money;
+use InvalidArgumentException;
 use Money\Currency;
 use Money\Exception\ParserException;
 use Money\Parser\BitcoinMoneyParser;
@@ -11,7 +12,6 @@ use Money\Parser\IntlMoneyParser;
 use NumberFormatter;
 use PHPUnit\Framework\TestCase;
 use stdClass;
-use InvalidArgumentException;
 
 class MoneyParserTraitTest extends TestCase
 {


### PR DESCRIPTION
Resolve #62, #67, #74 

**Casts types**

- [MoneyCast](https://github.com/cknow/laravel-money/blob/feat-casts/src/MoneyCast.php)
- [MoneyIntegerCast](https://github.com/cknow/laravel-money/blob/feat-casts/src/MoneyIntegerCast.php)
- [MoneyStringCast](https://github.com/cknow/laravel-money/blob/feat-casts/src/MoneyStringCast.php)
- [MoneyDecimalCast](https://github.com/cknow/laravel-money/blob/feat-casts/src/MoneyDecimalCast.php)

**Note**

`MoneyCast` uses `formatByDecimal` by default, in next major release it will be a abstract class.