### PR TITLE
Support Using Eloquent Accessor

### DIFF
--- a/src/Casts/MoneyCast.php
+++ b/src/Casts/MoneyCast.php
@@ -49,7 +49,7 @@ abstract class MoneyCast implements CastsAttributes
             return $value;
         }
 
-        return Money::parse($value, $this->getCurrency($attributes));
+        return Money::parse($value, $this->getCurrency($model));
     }
 
     /**
@@ -90,10 +90,10 @@ abstract class MoneyCast implements CastsAttributes
     /**
      * Get currency.
      *
-     * @param  array  $attributes
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return \Money\Currency
      */
-    protected function getCurrency(array $attributes)
+    protected function getCurrency(Model $model)
     {
         $defaultCode = Money::getDefaultCurrency();
 
@@ -108,7 +108,7 @@ abstract class MoneyCast implements CastsAttributes
             return $currency;
         }
 
-        $code = $attributes[$this->currency] ?? $defaultCode;
+        $code = $model->{$this->currency} ?? $defaultCode;
 
         return new Currency($code);
     }


### PR DESCRIPTION
With the previous implementation, when you tried to use an attribute that is generated using an [Eloquent accessor](https://laravel.com/docs/8.x/eloquent-mutators#accessors-and-mutators), this would not work and would automatically fallback to the default currency. This allows one to use an accessor field.