### PR TITLE
[PHP 8.1] Avoid deprecation message for jsonSerialize() return type

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -59,7 +59,7 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
             return $this->macroCall($method, $arguments);
         }
 
-        if (! method_exists($this->money, $method)) {
+        if (!method_exists($this->money, $method)) {
             return $this;
         }
 
@@ -72,7 +72,7 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
             'allocate', 'allocateTo',
         ];
 
-        if (! in_array($method, $methods)) {
+        if (!in_array($method, $methods)) {
             return $result;
         }
 
@@ -143,6 +143,7 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return array_merge(
@@ -208,7 +209,7 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
      */
     private static function convertResult($result)
     {
-        if (! is_array($result)) {
+        if (!is_array($result)) {
             return static::convert($result);
         }
 

--- a/src/Money.php
+++ b/src/Money.php
@@ -59,7 +59,7 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
             return $this->macroCall($method, $arguments);
         }
 
-        if (!method_exists($this->money, $method)) {
+        if (! method_exists($this->money, $method)) {
             return $this;
         }
 
@@ -72,7 +72,7 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
             'allocate', 'allocateTo',
         ];
 
-        if (!in_array($method, $methods)) {
+        if (! in_array($method, $methods)) {
             return $result;
         }
 
@@ -209,7 +209,7 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
      */
     private static function convertResult($result)
     {
-        if (!is_array($result)) {
+        if (! is_array($result)) {
             return static::convert($result);
         }
 


### PR DESCRIPTION
This PR adds the `#[\ReturnTypeWillChange]` attribute to let PHP 8.1 know that the Money::jsonSerialize() return type (`array`) is different from the default one (`mixed`).

This addition will avoid the deprecation message:
```
PHP Deprecated:  Return type of Cknow\Money\Money::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/cknow/laravel-money/src/Money.php on line 146
```

Thank you as always to maintain this great package :)