### PR TITLE
fix: support null values

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -43,7 +43,7 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
      */
     public function __construct($amount, Currency $currency)
     {
-        $amount = is_null($amount) ? (string) $amount : $amount;
+        $amount = is_null($amount) ? (int) $amount : $amount;
 
         $this->money = new \Money\Money($amount, $currency);
     }


### PR DESCRIPTION
[6.0.2 introduced breaking changes](https://github.com/cknow/laravel-money/issues/103) but I don't think #105 really fixes the issue it is still breaking on my end. Shouldn't the cast simply be an int cast?