### PR TITLE
Fixes integer and integerish floats behaviour

### DIFF
--- a/src/Casts/MoneyDecimalCast.php
+++ b/src/Casts/MoneyDecimalCast.php
@@ -25,4 +25,13 @@ class MoneyDecimalCast extends MoneyCast
 
         return parent::get($model, $key, $value, $attributes);
     }
+
+    public function set($model, string $key, $value, array $attributes)
+    {
+        if (filter_var($value, FILTER_VALIDATE_INT) !== false) {
+            $value = number_format($value, '2');
+        }
+
+        return parent::set($model, $key, $value, $attributes);
+    }
 }

--- a/src/Casts/MoneyDecimalCast.php
+++ b/src/Casts/MoneyDecimalCast.php
@@ -16,4 +16,15 @@ class MoneyDecimalCast extends MoneyCast
     {
         return $money->formatByDecimal();
     }
+
+    public function get($model, string $key, $value, array $attributes)
+    {
+        if (filter_var($value, FILTER_VALIDATE_INT) !== false) {
+            $value = number_format($value, '2');
+        }
+
+        return parent::get($model, $key, $value, $attributes);
+    }
+
+
 }

--- a/src/Casts/MoneyDecimalCast.php
+++ b/src/Casts/MoneyDecimalCast.php
@@ -25,6 +25,4 @@ class MoneyDecimalCast extends MoneyCast
 
         return parent::get($model, $key, $value, $attributes);
     }
-
-
 }

--- a/src/MoneyParserTrait.php
+++ b/src/MoneyParserTrait.php
@@ -37,7 +37,11 @@ trait MoneyParserTrait
 
         $currency = static::parseCurrency($currency);
 
-        if (is_int($value) || filter_var($value, FILTER_VALIDATE_INT) !== false) {
+        if (is_int($value)) {
+            return new Money($value * 100, $currency);
+        }
+
+        if (filter_var($value, FILTER_VALIDATE_INT) !== false) {
             return new Money($value, $currency);
         }
 

--- a/tests/MoneyCastTest.php
+++ b/tests/MoneyCastTest.php
@@ -111,7 +111,7 @@ class MoneyCastTest extends TestCase
         $user->money = 100;
         $user->wage = 70500.19;
         $user->debits = '¥213860';
-        $user->credits = 123;
+        $user->credits = 123.00;
 
         static::assertSame('10000', $user->money->getAmount());
         static::assertSame('USD', $user->money->getCurrency()->getCode());

--- a/tests/MoneyCastTest.php
+++ b/tests/MoneyCastTest.php
@@ -129,6 +129,7 @@ class MoneyCastTest extends TestCase
 
         $user->money = '100,000.22';
         $user->debits = 'Ƀ0.00012345';
+        $user->credits = 234;
 
         static::assertSame('10000022', $user->money->getAmount());
         static::assertSame('USD', $user->money->getCurrency()->getCode());
@@ -136,6 +137,10 @@ class MoneyCastTest extends TestCase
         static::assertSame('12345', $user->debits->getAmount());
         static::assertSame('XBT', $user->debits->getCurrency()->getCode());
         static::assertSame('XBT', $user->currency);
+
+        static::assertSame('23400', $user->credits->getAmount());
+        static::assertSame('$234.00', $user->credits->format());
+        static::assertSame('USD', $user->credits->getCurrency()->getCode());
 
         $user->save();
 
@@ -146,7 +151,7 @@ class MoneyCastTest extends TestCase
             'money' => '$100,000.22',
             'wage' => 7050019,
             'debits' => 0.00012345,
-            'credits' => 123.00,
+            'credits' => 234.00,
             'currency' => 'XBT',
         ]);
     }

--- a/tests/MoneyCastTest.php
+++ b/tests/MoneyCastTest.php
@@ -111,6 +111,7 @@ class MoneyCastTest extends TestCase
         $user->money = 100;
         $user->wage = 70500.19;
         $user->debits = '¥213860';
+        $user->credits = 123;
 
         static::assertSame('10000', $user->money->getAmount());
         static::assertSame('USD', $user->money->getCurrency()->getCode());
@@ -121,6 +122,10 @@ class MoneyCastTest extends TestCase
         static::assertSame('213860', $user->debits->getAmount());
         static::assertSame('JPY', $user->debits->getCurrency()->getCode());
         static::assertSame('JPY', $user->currency);
+
+        static::assertSame('12300', $user->credits->getAmount());
+        static::assertSame('$123.00', $user->credits->format());
+        static::assertSame('USD', $user->credits->getCurrency()->getCode());
 
         $user->money = '100,000.22';
         $user->debits = 'Ƀ0.00012345';
@@ -141,6 +146,7 @@ class MoneyCastTest extends TestCase
             'money' => '$100,000.22',
             'wage' => 7050019,
             'debits' => 0.00012345,
+            'credits' => 123.00,
             'currency' => 'XBT',
         ]);
     }

--- a/tests/MoneyCastTest.php
+++ b/tests/MoneyCastTest.php
@@ -83,7 +83,6 @@ class MoneyCastTest extends TestCase
             'credits' => 99.00,
             'currency' => 'AUD',
         ]);
-
     }
 
     public function testCastsMoneyWhenSettingCastedValues()

--- a/tests/MoneyParserTraitTest.php
+++ b/tests/MoneyParserTraitTest.php
@@ -19,7 +19,7 @@ class MoneyParserTraitTest extends TestCase
         static::assertEquals(Money::parse('100.00', 'USD'), Money::USD(10000));
         static::assertEquals(Money::parse('$1.00'), Money::USD(100));
         static::assertEquals(Money::parse('$1.00', 'USD'), Money::USD(100));
-        static::assertEquals(Money::parse(1, 'USD'), Money::USD(1));
+        static::assertEquals(Money::parse(1, 'USD'), Money::USD(100));
         static::assertEquals(Money::parse(1.10, 'USD'), Money::USD(110));
         static::assertEquals(Money::parse('100', 'USD'), Money::USD(100));
         static::assertEquals(Money::parse('1', 'USD'), Money::USD(1));


### PR DESCRIPTION
This fixes issue #107

The root cause for the worries was that the handling of integers and integerish values messes with the decimal casting. I fixed the parsing tests by forcing values directly into the database for the test and then retrieving (and casting) from there and forced handling of integers and integerish floats differently when casting into the database.