### PR TITLE
Fix parser

### DIFF
--- a/tests/MoneyParserTraitTest.php
+++ b/tests/MoneyParserTraitTest.php
@@ -16,11 +16,20 @@ class MoneyParserTraitTest extends TestCase
 {
     public function testParse()
     {
+        static::assertEquals(Money::parse(10.00, 'USD'), Money::USD(1000));
+        static::assertEquals(Money::parse(0.10, 'USD'), Money::USD(10));
+        static::assertEquals(Money::parse('0.10', 'USD'), Money::USD(10));
+        static::assertEquals(Money::parse(1.10, 'USD'), Money::USD(110));
+        static::assertEquals(Money::parse('1.10', 'USD'), Money::USD(110));
+        static::assertEquals(Money::parse(1.00, 'USD'), Money::USD(100));
+        static::assertEquals(Money::parse('1.00', 'USD'), Money::USD(100));
+        static::assertEquals(Money::parse(100.00, 'USD'), Money::USD(10000));
         static::assertEquals(Money::parse('100.00', 'USD'), Money::USD(10000));
         static::assertEquals(Money::parse('$1.00'), Money::USD(100));
         static::assertEquals(Money::parse('$1.00', 'USD'), Money::USD(100));
         static::assertEquals(Money::parse(1, 'USD'), Money::USD(1));
         static::assertEquals(Money::parse(1.10, 'USD'), Money::USD(110));
+        static::assertEquals(Money::parse(100, 'USD'), Money::USD(100));
         static::assertEquals(Money::parse('100', 'USD'), Money::USD(100));
         static::assertEquals(Money::parse('1', 'USD'), Money::USD(1));
         static::assertEquals(Money::parse(Money::USD(100)), Money::USD(100));


### PR DESCRIPTION
Resolve #108 

This pr fixes issues with floating values ​​like` 100.00` which is interpreted as `100`