### PR TITLE
Add option to force decimals on MoneyCast

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ protected $casts = [
     'money' => MoneyIntegerCast::class . ':AUD',
     // cast money as string using the currency defined in the model attribute 'currency'
     'money' => MoneyStringCast::class . ':currency',
+    // cast money as decimal using the defined currency and forcing decimals
+    'money' => MoneyDecimalCast::class . ':USD,true',
 ];
 ```
 

--- a/src/Casts/MoneyDecimalCast.php
+++ b/src/Casts/MoneyDecimalCast.php
@@ -10,10 +10,10 @@ class MoneyDecimalCast extends MoneyCast
      * Get formatter.
      *
      * @param  \Cknow\Money\Money  $money
-     * @return mixed
+     * @return float
      */
     protected function getFormatter(Money $money)
     {
-        return $money->formatByDecimal();
+        return (float) $money->formatByDecimal();
     }
 }

--- a/src/Casts/MoneyIntegerCast.php
+++ b/src/Casts/MoneyIntegerCast.php
@@ -10,10 +10,10 @@ class MoneyIntegerCast extends MoneyCast
      * Get formatter.
      *
      * @param  \Cknow\Money\Money  $money
-     * @return mixed
+     * @return int
      */
     protected function getFormatter(Money $money)
     {
-        return $money->getAmount();
+        return (int) $money->getAmount();
     }
 }

--- a/src/Casts/MoneyStringCast.php
+++ b/src/Casts/MoneyStringCast.php
@@ -10,10 +10,10 @@ class MoneyStringCast extends MoneyCast
      * Get formatter.
      *
      * @param  \Cknow\Money\Money  $money
-     * @return mixed
+     * @return string
      */
     protected function getFormatter(Money $money)
     {
-        return $money->formatByIntl();
+        return (string) $money->formatByIntl();
     }
 }

--- a/tests/Database/Models/User.php
+++ b/tests/Database/Models/User.php
@@ -34,6 +34,6 @@ class User extends Model
         'money' => MoneyStringCast::class,
         'wage' => MoneyIntegerCast::class.':EUR',
         'debits' => MoneyDecimalCast::class.':currency',
-        'credits' => MoneyDecimalCast::class.':USD',
+        'credits' => MoneyDecimalCast::class.':USD,true',
     ];
 }

--- a/tests/MoneyCastTest.php
+++ b/tests/MoneyCastTest.php
@@ -5,6 +5,7 @@ namespace Cknow\Money\Tests;
 use Cknow\Money\Money;
 use Cknow\Money\Tests\Database\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Money\Exception\ParserException;
 use Money\Money as BaseMoney;
@@ -33,18 +34,20 @@ class MoneyCastTest extends TestCase
 
     public function testCastsMoneyWhenRetrievingCastedValues()
     {
-        $user = User::create([
-            'money' => 1234.56,
+        DB::table('users')->insert([
+            'money' => '1234.56',
             'wage' => 50000,
             'debits' => null,
-            'credits' => null,
+            'credits' => 12.00,
             'currency' => 'AUD',
         ]);
+
+        $user = User::findOrFail(1);
 
         static::assertInstanceOf(Money::class, $user->money);
         static::assertInstanceOf(Money::class, $user->wage);
         static::assertNull($user->debits);
-        static::assertNull($user->credits);
+        static::assertInstanceOf(Money::class, $user->credits);
 
         static::assertSame('123456', $user->money->getAmount());
         static::assertSame('USD', $user->money->getCurrency()->getCode());


### PR DESCRIPTION
Resolves #111 , #107 

Sometimes we define a value as an integer without worrying about the decimal places, with this option enabled the decimal places will be automatically inserted

```php
class MyModel extends Model 
{
        protected $casts = [
                'price' => MoneyDecimalCast::class . ':USD,true',
        ];
}

$test = \App\Models\MyModel::factory()->create([
    'price' => 100
]);

dd($test->price);
```

$test1 amount is now 10000