### PR TITLE
Add rules `currency` and `money`

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,48 @@ class MyFormatter implements \Money\MoneyFormatter
 Money::USD(500)->formatByFormatter(new MyFormatter()); // My Formatter
 ```
 
+## Rules
+
+Below is a list of all available validation rules and their function:
+
+### currency
+
+The field under validation must be a valid currency.
+
+```php
+Validator::make([
+  'currency1' => 'USD',
+  'currency2' => 'EUR',
+  'currency3' => new \Money\Currency('BRL'),
+], [
+  'currency1' => new \Cknow\Money\Rules\Currency(),
+  'currency2' => new \Cknow\Money\Rules\Currency(),
+  'currency3' => 'currency',
+]);
+```
+
+### money
+
+The field under validation must be a valid money.
+
+```php
+Validator::make([
+  'money1' => '$10.00'
+  'money2' => '€10.00',
+  'money3' => 'R$10,00',
+  'money4' => '$10.00'
+  'money5' => '€10.00',
+  'money6' => 'R$10,00',
+], [
+  'money1' => new \Cknow\Money\Rules\Money(),
+  'money2' => new \Cknow\Money\Rules\Money('EUR'), // forcing currency
+  'money3' => new \Cknow\Money\Rules\Money('BRL', 'pt_BR'), // forcing currency and locale
+  'money4' => 'money',
+  'money5' => 'money:EUR', // forcing currency
+  'money6' => 'money:BRL,pt_BR', // forcing currency and locale
+]);
+```
+
 ## Casts
 
 At this stage the cast can be defined in the following ways:

--- a/src/MoneyServiceProvider.php
+++ b/src/MoneyServiceProvider.php
@@ -33,13 +33,13 @@ class MoneyServiceProvider extends ServiceProvider
             BladeExtension::register($blade);
         });
 
-        Validator::extend('currency', function($attribute, $value) {
+        Validator::extend('currency', function ($attribute, $value) {
             $rule = new Rules\Currency();
 
             return $rule->passes($attribute, $value);
         });
 
-        Validator::extend('money', function($attribute, $value, $parameters) {
+        Validator::extend('money', function ($attribute, $value, $parameters) {
             $rule = new Rules\Money(...$parameters);
 
             return $rule->passes($attribute, $value);

--- a/src/MoneyServiceProvider.php
+++ b/src/MoneyServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Cknow\Money;
 
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
 
@@ -30,6 +31,18 @@ class MoneyServiceProvider extends ServiceProvider
 
         $this->callAfterResolving(BladeCompiler::class, function ($blade) {
             BladeExtension::register($blade);
+        });
+
+        Validator::extend('currency', function($attribute, $value) {
+            $rule = new Rules\Currency();
+
+            return $rule->passes($attribute, $value);
+        });
+
+        Validator::extend('money', function($attribute, $value, $parameters) {
+            $rule = new Rules\Money(...$parameters);
+
+            return $rule->passes($attribute, $value);
         });
     }
 }

--- a/src/Rules/Currency.php
+++ b/src/Rules/Currency.php
@@ -9,10 +9,10 @@ class Currency implements Rule
 {
     /**
      * Determine if the validation rule passes.
-    *
-    * @param  string  $attribute
-    * @param  mixed  $value
-    * @return bool
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
     */
     public function passes($attribute, $value)
     {
@@ -21,8 +21,8 @@ class Currency implements Rule
 
     /**
      * Get the validation error message.
-    *
-    * @return string
+     *
+     * @return string
     */
     public function message()
     {

--- a/src/Rules/Currency.php
+++ b/src/Rules/Currency.php
@@ -13,7 +13,7 @@ class Currency implements Rule
      * @param  string  $attribute
      * @param  mixed  $value
      * @return bool
-    */
+     */
     public function passes($attribute, $value)
     {
         return Money::isValidCurrency($value);
@@ -23,7 +23,7 @@ class Currency implements Rule
      * Get the validation error message.
      *
      * @return string
-    */
+     */
     public function message()
     {
         $message = trans('validation.currency');

--- a/src/Rules/Currency.php
+++ b/src/Rules/Currency.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Cknow\Money\Rules;
+
+use Cknow\Money\Money;
+use Illuminate\Contracts\Validation\Rule;
+
+class Currency implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+    *
+    * @param  string  $attribute
+    * @param  mixed  $value
+    * @return bool
+    */
+    public function passes($attribute, $value)
+    {
+        return Money::isValidCurrency($value);
+    }
+
+    /**
+     * Get the validation error message.
+    *
+    * @return string
+    */
+    public function message()
+    {
+        $message = trans('validation.currency');
+
+        return $message === 'validation.currency'
+            ? 'The :attribute is not a valid currency.'
+            : $message;
+    }
+}

--- a/src/Rules/Money.php
+++ b/src/Rules/Money.php
@@ -55,7 +55,7 @@ class Money implements Rule
      * @param  string  $attribute
      * @param  mixed  $value
      * @return bool
-    */
+     */
     public function passes($attribute, $value)
     {
         try {
@@ -82,7 +82,7 @@ class Money implements Rule
      * Get the validation error message.
      *
      * @return string
-    */
+     */
     public function message()
     {
         $message = trans('validation.money');

--- a/src/Rules/Money.php
+++ b/src/Rules/Money.php
@@ -51,10 +51,10 @@ class Money implements Rule
 
     /**
      * Determine if the validation rule passes.
-    *
-    * @param  string  $attribute
-    * @param  mixed  $value
-    * @return bool
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
     */
     public function passes($attribute, $value)
     {
@@ -68,8 +68,8 @@ class Money implements Rule
                 $this->bitCointDigits
             );
 
-            return !(
-                $this->currency && !$money->getCurrency()->equals(\Cknow\Money\Money::parseCurrency($this->currency))
+            return ! (
+                $this->currency && ! $money->getCurrency()->equals(\Cknow\Money\Money::parseCurrency($this->currency))
             );
         } catch (InvalidArgumentException $e) {
             return false;
@@ -80,8 +80,8 @@ class Money implements Rule
 
     /**
      * Get the validation error message.
-    *
-    * @return string
+     *
+     * @return string
     */
     public function message()
     {

--- a/src/Rules/Money.php
+++ b/src/Rules/Money.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Cknow\Money\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use InvalidArgumentException;
+use Money\Exception\ParserException;
+
+class Money implements Rule
+{
+    /**
+     * @var \Money\Currency|string|null
+     */
+    protected $currency;
+
+    /**
+     * @var string|null
+     */
+    protected $locale;
+
+    /**
+     * @var \Money\Currencies|null
+     */
+    protected $currencies;
+
+    /**
+     * @var int|null
+     */
+    protected $bitCointDigits;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @param  \Money\Currency|string|null  $currency
+     * @param  string|null  $locale
+     * @param  \Money\Currencies|null  $currencies
+     * @param  int|null  $bitCointDigits
+     * @return void
+     */
+    public function __construct(
+        $currency = null,
+        $locale = null,
+        $currencies = null,
+        $bitCointDigits = null
+    ) {
+        $this->currency = $currency;
+        $this->locale = $locale;
+        $this->currencies = $currencies;
+        $this->bitCointDigits = $bitCointDigits;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+    *
+    * @param  string  $attribute
+    * @param  mixed  $value
+    * @return bool
+    */
+    public function passes($attribute, $value)
+    {
+        try {
+            $money = \Cknow\Money\Money::parse(
+                $value,
+                $this->currency,
+                false,
+                $this->locale,
+                $this->currencies,
+                $this->bitCointDigits
+            );
+
+            return !(
+                $this->currency && !$money->getCurrency()->equals(\Cknow\Money\Money::parseCurrency($this->currency))
+            );
+        } catch (InvalidArgumentException $e) {
+            return false;
+        } catch (ParserException $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Get the validation error message.
+    *
+    * @return string
+    */
+    public function message()
+    {
+        $message = trans('validation.money');
+
+        return $message === 'validation.money'
+            ? 'The :attribute is not a valid money.'
+            : $message;
+    }
+}

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -12,8 +12,8 @@ class MoneyTest extends TestCase
         static::assertEquals(Money::USD('$10.00'), Money::USD(1000));
         static::assertEquals(Money::USD('R$10.00'), Money::BRL(1000));
         static::assertEquals(Money::USD('$10.10'), Money::USD(1010));
-        static::assertEquals(Money::USD('R$10,10', false, 'pt-BR'), Money::BRL(1010));
-        static::assertEquals(Money::BRL('R$10,10', false, 'pt-BR'), Money::BRL(1010));
+        static::assertEquals(Money::USD('R$10,10', false, 'pt_BR'), Money::BRL(1010));
+        static::assertEquals(Money::BRL('R$10,10', false, 'pt_BR'), Money::BRL(1010));
         static::assertEquals(Money::USD(1000), Money::USD(1000));
         static::assertEquals(Money::USD(10.00), Money::USD(1000));
         static::assertEquals(Money::USD('1000'), Money::USD(1000));

--- a/tests/Rules/CurrencyTest.php
+++ b/tests/Rules/CurrencyTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Cknow\Money\Tests\Rules;
+
+use Cknow\Money\Rules\Currency;
+use Cknow\Money\Tests\TestCase;
+use Illuminate\Support\Facades\Validator;
+
+class CurrencyTest extends TestCase
+{
+    public function testValidationPasses()
+    {
+        $v = Validator::make(
+            [
+                'currency1' => 'USD',
+                'currency2' => 'EUR',
+                'currency3' => new \Money\Currency('BRL')
+            ],
+            [
+                'currency1' =>  'currency',
+                'currency2' =>  new Currency,
+                'currency3' =>  new Currency
+            ]
+        );
+
+        $this->assertFalse($v->fails());
+    }
+
+    public function testValidationFails()
+    {
+        $v = Validator::make(
+            [
+                'currency1' => 'foo',
+                'currency2' => 'bar'
+            ],
+            [
+                'currency1' =>  'currency',
+                'currency2' =>  new Currency
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals(['validation.currency'], $v->errors()->get('currency1'));
+        $this->assertEquals(['The currency2 is not a valid currency.'], $v->errors()->get('currency2'));
+    }
+}

--- a/tests/Rules/CurrencyTest.php
+++ b/tests/Rules/CurrencyTest.php
@@ -14,12 +14,12 @@ class CurrencyTest extends TestCase
             [
                 'currency1' => 'USD',
                 'currency2' => 'EUR',
-                'currency3' => new \Money\Currency('BRL')
+                'currency3' => new \Money\Currency('BRL'),
             ],
             [
                 'currency1' =>  'currency',
                 'currency2' =>  new Currency,
-                'currency3' =>  new Currency
+                'currency3' =>  new Currency,
             ]
         );
 
@@ -31,11 +31,11 @@ class CurrencyTest extends TestCase
         $v = Validator::make(
             [
                 'currency1' => 'foo',
-                'currency2' => 'bar'
+                'currency2' => 'bar',
             ],
             [
                 'currency1' =>  'currency',
-                'currency2' =>  new Currency
+                'currency2' =>  new Currency,
             ]
         );
 

--- a/tests/Rules/MoneyTest.php
+++ b/tests/Rules/MoneyTest.php
@@ -36,7 +36,7 @@ class MoneyTest extends TestCase
                 'money8' => new Money('BRL', 'pt_BR'),
                 'money9' => 'money:BRL,pt_BR',
                 'money10' => new Money,
-                'money11' => new Money
+                'money11' => new Money,
             ]
         );
 

--- a/tests/Rules/MoneyTest.php
+++ b/tests/Rules/MoneyTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Cknow\Money\Tests\Rules;
+
+use Cknow\Money\Rules\Money;
+use Cknow\Money\Tests\TestCase;
+use Illuminate\Support\Facades\Validator;
+use stdClass;
+
+class MoneyTest extends TestCase
+{
+    public function testValidationPasses()
+    {
+        $v = Validator::make(
+            [
+                'money1' => '10',
+                'money2' => 10,
+                'money3' => 10.00,
+                'money4' => 10.10,
+                'money5' => '10.10',
+                'money6' => '$10.10',
+                'money7' => '$10.10',
+                'money8' => 'R$10,00',
+                'money9' => 'R$10,00',
+                'money10' => \Money\Money::USD(10),
+                'money11' => new \Cknow\Money\Money(10),
+            ],
+            [
+                'money1' => 'money',
+                'money2' => new Money,
+                'money3' => new Money,
+                'money4' => new Money,
+                'money5' => new Money,
+                'money6' => new Money,
+                'money7' => new Money('USD'),
+                'money8' => new Money('BRL', 'pt_BR'),
+                'money9' => 'money:BRL,pt_BR',
+                'money10' => new Money,
+                'money11' => new Money
+            ]
+        );
+
+        $this->assertFalse($v->fails());
+    }
+
+    public function testValidationFails()
+    {
+        $v = Validator::make(
+            [
+                'money1' => 'foo',
+                'money2' => '$ 100,00',
+                'money3' => '$ 100, 00',
+                'money4' => 'R$ 1,00.000',
+                'money5' => 'R$ 1,.00',
+                'money6' => '$1.00',
+                'money7' => '$1.00',
+                'money8' => new stdClass,
+            ],
+            [
+                'money1' => 'money',
+                'money2' => new Money,
+                'money3' => new Money,
+                'money4' => new Money,
+                'money5' => new Money,
+                'money6' => new Money('BRL', 'pt_BR'),
+                'money7' => 'money:BRL,pt_BR',
+                'money8' => new Money,
+            ]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertEquals(['validation.money'], $v->errors()->get('money1'));
+        $this->assertEquals(['The money2 is not a valid money.'], $v->errors()->get('money2'));
+        $this->assertEquals(['The money3 is not a valid money.'], $v->errors()->get('money3'));
+        $this->assertEquals(['The money4 is not a valid money.'], $v->errors()->get('money4'));
+        $this->assertEquals(['The money5 is not a valid money.'], $v->errors()->get('money5'));
+        $this->assertEquals(['The money6 is not a valid money.'], $v->errors()->get('money6'));
+        $this->assertEquals(['validation.money'], $v->errors()->get('money7'));
+        $this->assertEquals(['The money8 is not a valid money.'], $v->errors()->get('money8'));
+    }
+}


### PR DESCRIPTION
Resolve #49

## Rules

Below is a list of all available validation rules and their function:

### currency

The field under validation must be a valid currency.

```php
Validator::make([
  'currency1' => 'USD',
  'currency2' => 'EUR',
  'currency3' => new \Money\Currency('BRL'),
], [
  'currency1' => new \Cknow\Money\Rules\Currency(),
  'currency2' => new \Cknow\Money\Rules\Currency(),
  'currency3' => 'currency',
]);
```

### money

The field under validation must be a valid money.

```php
Validator::make([
  'money1' => '$10.00'
  'money2' => '€10.00',
  'money3' => 'R$10,00',
  'money4' => '$10.00'
  'money5' => '€10.00',
  'money6' => 'R$10,00',
], [
  'money1' => new \Cknow\Money\Rules\Money(),
  'money2' => new \Cknow\Money\Rules\Money('EUR'), // forcing currency
  'money3' => new \Cknow\Money\Rules\Money('BRL', 'pt_BR'), // forcing currency and locale
  'money4' => 'money',
  'money5' => 'money:EUR', // forcing currency
  'money6' => 'money:BRL,pt_BR', // forcing currency and locale
]);
```