### PR TITLE
Fill the Currrency Field without checking

### DIFF
--- a/src/Casts/MoneyCast.php
+++ b/src/Casts/MoneyCast.php
@@ -89,7 +89,7 @@ abstract class MoneyCast implements CastsAttributes
 
         $amount = $this->getFormatter($money);
 
-        if (array_key_exists($this->currency, $attributes)) {
+        if ($this->currency) {
             return [$key => $amount, $this->currency => $money->getCurrency()->getCode()];
         }
 

--- a/src/Casts/MoneyCast.php
+++ b/src/Casts/MoneyCast.php
@@ -89,7 +89,7 @@ abstract class MoneyCast implements CastsAttributes
 
         $amount = $this->getFormatter($money);
 
-        if ($this->currency && !Money::isValidCurrency($this->currency)) {
+        if ($this->currency && ! Money::isValidCurrency($this->currency)) {
             return [$key => $amount, $this->currency => $money->getCurrency()->getCode()];
         }
 

--- a/src/Casts/MoneyCast.php
+++ b/src/Casts/MoneyCast.php
@@ -89,7 +89,7 @@ abstract class MoneyCast implements CastsAttributes
 
         $amount = $this->getFormatter($money);
 
-        if ($this->currency) {
+        if ($this->currency && !Money::isValidCurrency($this->currency)) {
             return [$key => $amount, $this->currency => $money->getCurrency()->getCode()];
         }
 

--- a/tests/MoneyCastTest.php
+++ b/tests/MoneyCastTest.php
@@ -160,5 +160,6 @@ class MoneyCastTest extends TestCase
 
         static::assertSame('10099', $user->debits->getAmount());
         static::assertSame('USD', $user->debits->getCurrency()->getCode());
+        static::assertSame('USD', $user->currency);
     }
 }

--- a/tests/MoneyCastTest.php
+++ b/tests/MoneyCastTest.php
@@ -152,8 +152,8 @@ class MoneyCastTest extends TestCase
         new User(['money' => 'abc']);
     }
 
-    public function testSetCurrencyForNewEmptyUser() {
-        
+    public function testSetCurrencyForNewEmptyUser()
+    {
         $user = new User();
 
         $user->debits = 100.99;

--- a/tests/MoneyCastTest.php
+++ b/tests/MoneyCastTest.php
@@ -151,4 +151,14 @@ class MoneyCastTest extends TestCase
 
         new User(['money' => 'abc']);
     }
+
+    public function testSetCurrencyForNewEmptyUser() {
+        
+        $user = new User();
+
+        $user->debits = 100.99;
+
+        static::assertSame('10099', $user->debits->getAmount());
+        static::assertSame('USD', $user->debits->getCurrency()->getCode());
+    }
 }


### PR DESCRIPTION
Dears,

During my development i found that the currency fields doesn't get filled with new instances and i have to fill the currency manually 

i checked the code and it seems that it checks if the field exists in the attribute before filling which for new instances wouldn't be correct.

so i don't think we need to do the check as it's already passed as a parameter.

For anyone facing the same issue you can just initialize the currency field using attributes  inside the model
```php
class Request extends Model
{
    protected $attributes = [
        'currency' => '',
    ];
}
``` 