### PR TITLE
Fixes usage of `ROUND_UP` and `ROUND_DOWN`

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -93,17 +93,10 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
      */
     public function divide($divisor, $roundingMode = \Money\Money::ROUND_HALF_UP)
     {
-        if (
-            is_int($divisor)
-            || (filter_var($divisor, FILTER_VALIDATE_INT) !== false && ! is_float($divisor))
-        ) {
-            return $this->__call('divide', [$divisor, $roundingMode]);
-        }
-
-        $money = $this->getMoney();
-        $calculator = static::resolveCalculator();
-
-        return new self((int) round($calculator->divide($money->getAmount(), $divisor), 0, $roundingMode), $money->getCurrency());
+        return $this->__call('divide', [
+            is_int($divisor) ? $divisor : strval($divisor),
+            $roundingMode,
+        ]);
     }
 
     /**
@@ -115,17 +108,10 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
      */
     public function multiply($multiplier, $roundingMode = \Money\Money::ROUND_HALF_UP)
     {
-        if (
-            is_int($multiplier)
-            || (filter_var($multiplier, FILTER_VALIDATE_INT) !== false && ! is_float($multiplier))
-        ) {
-            return $this->__call('multiply', [$multiplier, $roundingMode]);
-        }
-
-        $money = $this->getMoney();
-        $calculator = static::resolveCalculator();
-
-        return new self((int) round($calculator->multiply($money->getAmount(), $multiplier), 0, $roundingMode), $money->getCurrency());
+        return $this->__call('multiply', [
+            is_int($multiplier) ? $multiplier : strval($multiplier),
+            $roundingMode,
+        ]);
     }
 
     /**

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -91,6 +91,8 @@ class MoneyTest extends TestCase
         static::assertEquals(Money::USD(11550), Money::USD(35, true)->multiply(3.3));
         static::assertEquals(Money::USD(3651), Money::USD(2501)->multiply(1.46));
         static::assertEquals(Money::USD(3652), Money::USD(2501)->multiply(1.46, \Money\Money::ROUND_UP));
+        static::assertEquals(Money::USD(3649), Money::USD(2499)->multiply(1.46));
+        static::assertEquals(Money::USD(3648), Money::USD(2499)->multiply(1.46, \Money\Money::ROUND_DOWN));
     }
 
     public function testDivide()
@@ -104,6 +106,8 @@ class MoneyTest extends TestCase
         static::assertEquals(Money::USD(86.52), Money::USD(199, true)->divide(2.3));
         static::assertEquals(Money::USD(5321), Money::USD(2501)->divide(0.47));
         static::assertEquals(Money::USD(5322), Money::USD(2501)->divide(0.47, \Money\Money::ROUND_UP));
+        static::assertEquals(Money::USD(5326), Money::USD(2503)->divide(0.47));
+        static::assertEquals(Money::USD(5325), Money::USD(2503)->divide(0.47, \Money\Money::ROUND_DOWN));
     }
 
     public function testMod()

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -89,7 +89,8 @@ class MoneyTest extends TestCase
         static::assertEquals(Money::USD(102), Money::USD(35)->multiply(2.9));
         static::assertEquals(Money::USD(10150), Money::USD(35, true)->multiply(2.9));
         static::assertEquals(Money::USD(11550), Money::USD(35, true)->multiply(3.3));
-        static::assertEquals(Money::USD(3317), Money::USD(199, true)->multiply(0.16666667));
+        static::assertEquals(Money::USD(3651), Money::USD(2501)->multiply(1.46));
+        static::assertEquals(Money::USD(3652), Money::USD(2501)->multiply(1.46, \Money\Money::ROUND_UP));
     }
 
     public function testDivide()
@@ -101,6 +102,8 @@ class MoneyTest extends TestCase
         static::assertEquals(Money::USD(12.07), Money::USD(35, true)->divide(2.9));
         static::assertEquals(Money::USD(10.61), Money::USD(35, true)->divide(3.3));
         static::assertEquals(Money::USD(86.52), Money::USD(199, true)->divide(2.3));
+        static::assertEquals(Money::USD(5321), Money::USD(2501)->divide(0.47));
+        static::assertEquals(Money::USD(5322), Money::USD(2501)->divide(0.47, \Money\Money::ROUND_UP));
     }
 
     public function testMod()

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -89,6 +89,7 @@ class MoneyTest extends TestCase
         static::assertEquals(Money::USD(102), Money::USD(35)->multiply(2.9));
         static::assertEquals(Money::USD(10150), Money::USD(35, true)->multiply(2.9));
         static::assertEquals(Money::USD(11550), Money::USD(35, true)->multiply(3.3));
+        static::assertEquals(Money::USD(3317), Money::USD(199, true)->multiply(0.16666667));
         static::assertEquals(Money::USD(3651), Money::USD(2501)->multiply(1.46));
         static::assertEquals(Money::USD(3652), Money::USD(2501)->multiply(1.46, \Money\Money::ROUND_UP));
         static::assertEquals(Money::USD(3649), Money::USD(2499)->multiply(1.46));


### PR DESCRIPTION
Use parent dependency multiply and divide so we can cover the rounding.

Convert non-int multipliers to strings since we can only send int or floats to the \Money\Money class

Resolves #133 