### PR TITLE
Fix String interpolation deprecated in PHP8.2: use {$var} instead of ${var}

### DIFF
--- a/src/BladeExtension.php
+++ b/src/BladeExtension.php
@@ -14,11 +14,11 @@ class BladeExtension
     public static function register(BladeCompiler $compiler)
     {
         $compiler->directive('currency', function ($expression) {
-            return "<?php echo currency(${expression}); ?>";
+            return "<?php echo currency({$expression}); ?>";
         });
 
         $compiler->directive('money', function ($expression) {
-            return "<?php echo money(${expression}); ?>";
+            return "<?php echo money({$expression}); ?>";
         });
 
         self::registerAggregations($compiler);
@@ -33,19 +33,19 @@ class BladeExtension
     private static function registerAggregations(BladeCompiler $compiler)
     {
         $compiler->directive('money_min', function ($expression) {
-            return "<?php echo money_min(${expression}); ?>";
+            return "<?php echo money_min({$expression}); ?>";
         });
 
         $compiler->directive('money_max', function ($expression) {
-            return "<?php echo money_max(${expression}); ?>";
+            return "<?php echo money_max({$expression}); ?>";
         });
 
         $compiler->directive('money_avg', function ($expression) {
-            return "<?php echo money_avg(${expression}); ?>";
+            return "<?php echo money_avg({$expression}); ?>";
         });
 
         $compiler->directive('money_sum', function ($expression) {
-            return "<?php echo money_sum(${expression}); ?>";
+            return "<?php echo money_sum({$expression}); ?>";
         });
     }
 
@@ -57,23 +57,23 @@ class BladeExtension
     private static function registerParsers(BladeCompiler $compiler)
     {
         $compiler->directive('money_parse', function ($expression) {
-            return "<?php echo money_parse(${expression}); ?>";
+            return "<?php echo money_parse({$expression}); ?>";
         });
 
         $compiler->directive('money_parse_by_bitcoin', function ($expression) {
-            return "<?php echo money_parse_by_bitcoin(${expression}); ?>";
+            return "<?php echo money_parse_by_bitcoin({$expression}); ?>";
         });
 
         $compiler->directive('money_parse_by_decimal', function ($expression) {
-            return "<?php echo money_parse_by_decimal(${expression}); ?>";
+            return "<?php echo money_parse_by_decimal({$expression}); ?>";
         });
 
         $compiler->directive('money_parse_by_intl', function ($expression) {
-            return "<?php echo money_parse_by_intl(${expression}); ?>";
+            return "<?php echo money_parse_by_intl({$expression}); ?>";
         });
 
         $compiler->directive('money_parse_by_intl_localized_decimal', function ($expression) {
-            return "<?php echo money_parse_by_intl_localized_decimal(${expression}); ?>";
+            return "<?php echo money_parse_by_intl_localized_decimal({$expression}); ?>";
         });
     }
 }


### PR DESCRIPTION
Fix for Issue #138 