### PR TITLE
[8.x] Support Laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,23 +10,23 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [7.3, 7.4, 8.0, 8.1, 8.2]
-        laravel: [7.*, 8.*, 9.*, 10.*]
+        php: [8.1, 8.2, 8.3]
+        laravel: [9.*, 10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         exclude:
-          - php: 8.1
-            stability: prefer-lowest
-          - php: 8.2
-            stability: prefer-lowest
+          - laravel: 9.*
+            php: 8.3
+          - laravel: 11.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
@@ -45,4 +45,4 @@ jobs:
         run: vendor/bin/phpunit --verbose
 
       - name: Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit
 
       - name: Coverage
         uses: codecov/codecov-action@v4

--- a/.phpunit-watcher.yml
+++ b/.phpunit-watcher.yml
@@ -1,7 +1,0 @@
-watch:
-  directories:
-    - config
-    - resources
-    - src
-    - tests
-  fileMask: '*.php'

--- a/composer.json
+++ b/composer.json
@@ -16,19 +16,18 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "ext-intl": "*",
-        "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
-        "illuminate/view": "^7.0|^8.0|^9.0|^10.0",
-        "moneyphp/money": "^3.3|^4.2"
+        "illuminate/support": "^9.0|^10.0|^11.0",
+        "illuminate/view": "^9.0|^10.0|^11.0",
+        "moneyphp/money": "^4.2"
     },
     "require-dev": {
-        "graham-campbell/testbench": "^5.7",
-        "illuminate/filesystem": "^7.0|^8.0|^9.0|^10.0",
+        "graham-campbell/testbench": "^6.0",
+        "illuminate/filesystem": "^9.0|^10.0|^11.0",
         "mockery/mockery": "^1.6",
-        "phpunit/phpunit": "^8.5|^9.5.10|^10.0",
-        "spatie/phpunit-watcher": "^1.23"
+        "phpunit/phpunit": "^10.0"
     },
     "autoload": {
         "psr-4": {
@@ -59,7 +58,6 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "test": "vendor/bin/phpunit",
-        "watch": "vendor/bin/phpunit-watcher watch"
+        "test": "vendor/bin/phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "graham-campbell/testbench": "^6.0",
         "illuminate/filesystem": "^9.0|^10.0|^11.0",
         "mockery/mockery": "^1.6",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true"
->
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-        <report>
-            <clover outputFile="clover.xml"/>
-            <text outputFile="php://stdout"/>
-        </report>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <report>
+      <clover outputFile="clover.xml"/>
+      <text outputFile="php://stdout"/>
+    </report>
+  </coverage>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/MoneyCastTest.php
+++ b/tests/MoneyCastTest.php
@@ -25,9 +25,12 @@ class MoneyCastTest extends TestCase
     {
         parent::setUp();
 
-        $this->loadMigrationsFrom(__DIR__.'/Database/Migrations');
-
         Money::setCurrencies(config('money.currencies'));
+    }
+
+    protected function defineDatabaseMigrations(): void
+    {
+        $this->loadMigrationsFrom(__DIR__.'/Database/Migrations');
     }
 
     public function testCastsMoneyWhenRetrievingCastedValues()

--- a/tests/MoneyFormatterSerializerTest.php
+++ b/tests/MoneyFormatterSerializerTest.php
@@ -9,7 +9,7 @@ use Cknow\Money\Serializer\IntegerMoneySerializer;
 use Cknow\Money\Serializer\StringMoneySerializer;
 use InvalidArgumentException;
 
-class MoneySerializerTraitTest extends TestCase
+class MoneyFormatterSerializerTest extends TestCase
 {
     public function testSerialize()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,7 +13,7 @@ abstract class TestCase extends AbstractPackageTestCase
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
-    protected function getEnvironmentSetUp($app)
+    protected function getEnvironmentSetUp($app): void
     {
         $app->config->set('money.locale', 'en_US');
 
@@ -25,7 +25,7 @@ abstract class TestCase extends AbstractPackageTestCase
      *
      * @return string
      */
-    protected function getServiceProviderClass()
+    protected static function getServiceProviderClass(): string
     {
         return MoneyServiceProvider::class;
     }


### PR DESCRIPTION
Laravel 11 will be released in March, this PR prepares this package for Laravel 11. It also:

- Drops support for PHP-versions below 8.1, because they are not supported anymore
- Drops support for Laravel-versions below 9 (Laravel 9 itself is also EOL, but that allows developers on that version to prepare upgrades to a later version)
- Uses the latest version of Testbench and thus is running with PHPunit 10
- It drops support for the 3.x version of Money, because that version doesn't support PHP 8.0 and upwards
- It bumps the Github Action-dependencies to the latest stable version

It think this one should be merged into the next major release of this package.