### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ composer require cknow/laravel-money
 or add this to require section in your composer.json file:
 
 ```bash
-"cknow/laravel-money": "^7.0"
+"cknow/laravel-money": "^8.0"
 ```
 
 then run `composer update`

--- a/README.md
+++ b/README.md
@@ -127,7 +127,10 @@ Money::parseByIntlLocalizedDecimal('1.00', 'USD'); // Money::USD(100)
 ```php
 class MyFormatter implements \Money\MoneyFormatter
 {
-    public function format(\Money\Money $money)
+    /**
+     * Formats a Money object as string.
+     */
+    public function format(\Money\Money $money): string
     {
         return 'My Formatter';
     }


### PR DESCRIPTION
The `MoneyFormatter` interface requires a string as return type.