### PR TITLE
feature(currency): allow enums to be passed as currency

### DIFF
--- a/src/CurrenciesTrait.php
+++ b/src/CurrenciesTrait.php
@@ -34,6 +34,14 @@ trait CurrenciesTrait
             return new Currency($currency);
         }
 
+        if ($currency instanceof \StringBackedEnum) {
+            return new Currency($currency->value);
+        }
+
+        if ($currency instanceof \UnitEnum) {
+            return new Currency($currency->name);
+        }
+
         return $currency;
     }
 

--- a/tests/Enums/CurrencyIntBacked.php
+++ b/tests/Enums/CurrencyIntBacked.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Cknow\Money\Tests\Enums;
+
+enum CurrencyIntBacked: int
+{
+    case USD = 1;
+}

--- a/tests/Enums/CurrencyNotBacked.php
+++ b/tests/Enums/CurrencyNotBacked.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Cknow\Money\Tests\Enums;
+
+enum CurrencyNotBacked
+{
+    case USD;
+}

--- a/tests/Enums/CurrencyStringBacked.php
+++ b/tests/Enums/CurrencyStringBacked.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Cknow\Money\Tests\Enums;
+
+enum CurrencyStringBacked: string
+{
+    case USD = 'USD';
+}

--- a/tests/MoneyParserTraitTest.php
+++ b/tests/MoneyParserTraitTest.php
@@ -3,6 +3,9 @@
 namespace Cknow\Money\Tests;
 
 use Cknow\Money\Money;
+use Cknow\Money\Tests\Enums\CurrencyIntBacked;
+use Cknow\Money\Tests\Enums\CurrencyNotBacked;
+use Cknow\Money\Tests\Enums\CurrencyStringBacked;
 use InvalidArgumentException;
 use Money\Currency;
 use Money\Exception\ParserException;
@@ -99,6 +102,14 @@ class MoneyParserTraitTest extends TestCase
         $this->expectExceptionMessage('Invalid value {}');
 
         Money::parse(new stdClass);
+    }
+
+    public function test_parse_currency()
+    {
+        static::assertEquals(Money::parseCurrency('USD'), new Currency('USD'));
+        static::assertEquals(Money::parseCurrency(CurrencyStringBacked::USD), new Currency('USD'));
+        static::assertEquals(Money::parseCurrency(CurrencyIntBacked::USD), new Currency('USD'));
+        static::assertEquals(Money::parseCurrency(CurrencyNotBacked::USD), new Currency('USD'));
     }
 
     public function test_parse_invalid_money()


### PR DESCRIPTION
It's really a common case to define currencies as `enum`, espacially with PHP 8.1, laravel also supports them (both saving and retrieving from the database).

### Usecase

```php

// Enums/Currency.php
enum Currency: string {
   case USD = 'USD';
}

// Models/Item.php
class Item extends Model {
   protected function casts(): array {
       return [
           'total' => MoneyDecimalCast::class . ':currency',
           'currency' => Currency::class,
       ];
   }
}

```

Without this, `Money::parseCurrency` just returns the enum passed to it and then `Money\Money` fails with exception, since it require `$currency` to be either `string` or `Money\Currency`