### PR TITLE
Install correct framework version in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,9 @@ jobs:
           coverage: xdebug
 
       - name: Install dependencies
-        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-suggest
+        run: |
+          composer require --no-update laravel/framework:${{ matrix.laravel }}
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests
         run: vendor/bin/phpunit


### PR DESCRIPTION
Right now, the CI isn't installing the matrix configured Laravel version (see https://github.com/cknow/laravel-money/actions/runs/23339258353/job/67888623456 for an example; it says PHP 8.5 and Laravel 13 but the install step shows `Locking laravel/framework (v11.50.0)`).  This change will pin the framework to the right version when installing to ensure tests run with the right dependencies.